### PR TITLE
fix: Allow space inside project path.

### DIFF
--- a/Plugins/Confidential/CLI/SwiftConfidentialTool+ObfuscateCommand.swift
+++ b/Plugins/Confidential/CLI/SwiftConfidentialTool+ObfuscateCommand.swift
@@ -7,8 +7,8 @@ extension SwiftConfidentialTool {
         var cliArguments: [String] {
             [
                 "obfuscate",
-                "--configuration", configuration.path(),
-                "--output", output.path()
+                "--configuration", configuration.path(percentEncoded: false),
+                "--output", output.path(percentEncoded: false)
             ]
         }
 

--- a/Plugins/Confidential/plugin.swift
+++ b/Plugins/Confidential/plugin.swift
@@ -68,7 +68,7 @@ extension Confidential: XcodeBuildToolPlugin {
                     .appending(fileName: C.Configuration.expectedFileName, with: fileExtension)
             }
             .first {
-                FileManager.default.fileExists(atPath: $0.path())
+                FileManager.default.fileExists(atPath: $0.path(percentEncoded: false))
             }
     }
 }


### PR DESCRIPTION
I found that if there is a space inside the project path, it won't generate any ObfuscatedSources. It won't throw any errors.

This pull request fixes this problem.